### PR TITLE
Define Output Schemas for FastAPI Endpoints

### DIFF
--- a/backend/portfolio_trajectory/schemas/base.py
+++ b/backend/portfolio_trajectory/schemas/base.py
@@ -1,0 +1,10 @@
+"""Module providing the BaseModel useful for validation"""
+
+from pydantic import BaseModel, ConfigDict
+from pydantic.alias_generators import to_camel
+
+
+class CamelModel(BaseModel):
+    """BaseModel that automatically converts camelCase to snake_case and vice versa."""
+
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)

--- a/backend/portfolio_trajectory/schemas/output.py
+++ b/backend/portfolio_trajectory/schemas/output.py
@@ -4,42 +4,96 @@ from portfolio_trajectory.schemas.base import CamelModel
 
 
 class ValueArray(CamelModel):
-    """Represents arrays of nominal and real values."""
+    """Represents arrays of nominal and real values.
+
+    Attributes
+    ----------
+    nominal : list[float]
+        Array of nominal values in the simulation.
+    real : list[float]
+        Array of real (inflation-adjusted) values in the simulation.
+    """
 
     nominal: list[float]
     real: list[float]
 
 
 class SingleValue(CamelModel):
-    """Represents a pair of nominal and real single values."""
+    """Represents a pair of nominal and real single values.
+
+    Attributes
+    ----------
+    nominal : float
+        Nominal value of the metric.
+    real : float
+        Real (inflation-adjusted) value of the metric.
+    """
 
     nominal: float
     real: float
 
 
 class PathData(CamelModel):
-    """Represents a path entry with an identifier and associated values."""
+    """Represents a path entry with an identifier and associated values.
+
+    Attributes
+    ----------
+    id : int
+        Unique identifier for the path.
+    values : ValueArray
+        Nominal and real values associated with the path.
+    """
 
     id: int
     values: ValueArray
 
 
 class Paths(CamelModel):
-    """Holds collections of balance and return path data."""
+    """Holds collections of balance and return path data.
+
+    Attributes
+    ----------
+    balances : list[PathData]
+        list of balance path data entries.
+    returns : list[PathData]
+        list of return path data entries.
+    """
 
     balances: list[PathData]
     returns: list[PathData]
 
 
 class PercentilePath(CamelModel):
-    """Represents percentile-based path data with corresponding values."""
+    """Represents percentile-based path data with corresponding values.
+
+    Attributes
+    ----------
+    percentile : int
+        Percentile rank (e.g., 50 for median).
+    values : ValueArray
+        Nominal and real values at this percentile.
+    """
 
     percentile: int
     values: ValueArray
 
 
 class MetricData(CamelModel):
-    """Represents a computed metric for a specific path, including its percentile and value."""
+    """Represents a computed metric for a specific path, including its percentile and value.
+
+    Attributes
+    ----------
+    percentile : int
+        Percentile rank of the metric (e.g., 90 for 90th percentile).
+    value : SingleValue
+        Nominal and real values of the metric.
+    example_path_id : int
+        Identifier of an example path for this metric.
+
+    Notes
+    -----
+    Inherits from CamelModel, enabling camelCase JSON input/output (e.g., 'examplePathId' for 'example_path_id').
+    """
 
     percentile: int
     value: SingleValue
@@ -47,14 +101,48 @@ class MetricData(CamelModel):
 
 
 class Parameters(CamelModel):
-    """Holds simulation parameters such as the number of steps and paths."""
+    """Holds simulation parameters such as the number of steps and paths.
+
+    Attributes
+    ----------
+    num_steps : int
+        Number of time steps in the simulation.
+    num_paths : int
+        Number of simulated paths.
+
+    Notes
+    -----
+    Inherits from CamelModel, enabling camelCase JSON input/output (e.g., 'numSteps' for 'num_steps').
+    """
 
     num_steps: int
     num_paths: int
 
 
 class Metrics(CamelModel):
-    """Contains various metric collections computed from the paths."""
+    """Contains various metric collections computed from the paths.
+
+    Attributes
+    ----------
+    percentile_balances : list[PercentilePath]
+        Percentile-based balance paths.
+    end_balance : list[MetricData]
+        End balance metrics across percentiles.
+    mean_return : list[MetricData]
+        Mean return metrics across percentiles.
+    volatility : list[MetricData]
+        Volatility metrics across percentiles.
+    max_drawdown : list[MetricData]
+        Maximum drawdown metrics across percentiles.
+    contributions : list[MetricData]
+        Contribution metrics across percentiles.
+    withdrawals : list[MetricData]
+        Withdrawal metrics across percentiles.
+
+    Notes
+    -----
+    Inherits from CamelModel, enabling camelCase JSON input/output (e.g., 'endBalance' for 'end_balance').
+    """
 
     percentile_balances: list[PercentilePath]
     end_balance: list[MetricData]
@@ -66,7 +154,17 @@ class Metrics(CamelModel):
 
 
 class Data(CamelModel):
-    """Represents the complete dataset including parameters, paths, and metrics."""
+    """Represents the complete dataset including parameters, paths, and metrics.
+
+    Attributes
+    ----------
+    parameters : Parameters
+        Simulation parameters.
+    paths : Paths
+        Balance and return path data.
+    metrics : Metrics
+        Computed metrics from the paths.
+    """
 
     parameters: Parameters
     paths: Paths

--- a/backend/portfolio_trajectory/schemas/output.py
+++ b/backend/portfolio_trajectory/schemas/output.py
@@ -1,0 +1,73 @@
+"""Import CamelModel for case conversion."""
+
+from portfolio_trajectory.schemas.base import CamelModel
+
+
+class ValueArray(CamelModel):
+    """Represents arrays of nominal and real values."""
+
+    nominal: list[float]
+    real: list[float]
+
+
+class SingleValue(CamelModel):
+    """Represents a pair of nominal and real single values."""
+
+    nominal: float
+    real: float
+
+
+class PathData(CamelModel):
+    """Represents a path entry with an identifier and associated values."""
+
+    id: int
+    values: ValueArray
+
+
+class Paths(CamelModel):
+    """Holds collections of balance and return path data."""
+
+    balances: list[PathData]
+    returns: list[PathData]
+
+
+class PercentilePath(CamelModel):
+    """Represents percentile-based path data with corresponding values."""
+
+    percentile: int
+    values: ValueArray
+
+
+class MetricData(CamelModel):
+    """Represents a computed metric for a specific path, including its percentile and value."""
+
+    percentile: int
+    value: SingleValue
+    example_path_id: int
+
+
+class Parameters(CamelModel):
+    """Holds simulation parameters such as the number of steps and paths."""
+
+    num_steps: int
+    num_paths: int
+
+
+class Metrics(CamelModel):
+    """Contains various metric collections computed from the paths."""
+
+    percentile_balances: list[PercentilePath]
+    end_balance: list[MetricData]
+    mean_return: list[MetricData]
+    volatility: list[MetricData]
+    max_drawdown: list[MetricData]
+    contributions: list[MetricData]
+    withdrawals: list[MetricData]
+
+
+class Data(CamelModel):
+    """Represents the complete dataset including parameters, paths, and metrics."""
+
+    parameters: Parameters
+    paths: Paths
+    metrics: Metrics

--- a/backend/tests/test_schemas_output.py
+++ b/backend/tests/test_schemas_output.py
@@ -1,0 +1,254 @@
+import pytest
+from pydantic import ValidationError
+from portfolio_trajectory.schemas.output import (
+    ValueArray,
+    SingleValue,
+    PathData,
+    Paths,
+    PercentilePath,
+    MetricData,
+    Parameters,
+    Metrics,
+    Data,
+)
+
+
+# Test ValueArray
+def test_value_array_valid():
+    """Test ValueArray with valid float lists."""
+    data = {"nominal": [1.0, 2.0], "real": [1.5, 2.5]}
+    va = ValueArray(**data)
+    assert va.nominal == [1.0, 2.0]
+    assert va.real == [1.5, 2.5]
+
+
+def test_value_array_invalid_type():
+    """Test ValueArray with invalid type in nominal list."""
+    data = {"nominal": ["string"], "real": [1.0]}
+    with pytest.raises(ValidationError) as exc_info:
+        ValueArray(**data)
+    assert "nominal" in str(exc_info.value)
+
+
+# Test SingleValue
+def test_single_value_valid():
+    """Test SingleValue with valid float values."""
+    data = {"nominal": 10.0, "real": 12.0}
+    sv = SingleValue(**data)
+    assert sv.nominal == 10.0
+    assert sv.real == 12.0
+
+
+def test_single_value_missing_field():
+    """Test SingleValue with missing required field."""
+    data = {"nominal": 5.0}  # Missing 'real'
+    with pytest.raises(ValidationError) as exc_info:
+        SingleValue(**data)
+    assert "real" in str(exc_info.value)
+
+
+# Test PathData
+def test_path_data_valid():
+    """Test PathData with valid id and values."""
+    data = {"id": 1, "values": {"nominal": [1.0, 2.0], "real": [1.5, 2.5]}}
+    pd = PathData(**data)
+    assert pd.id == 1
+    assert isinstance(pd.values, ValueArray)
+    assert pd.values.nominal == [1.0, 2.0]
+
+
+def test_path_data_invalid_values():
+    """Test PathData with invalid values type."""
+    data = {"id": 1, "values": {"nominal": ["bad"], "real": [1.0]}}
+    with pytest.raises(ValidationError) as exc_info:
+        PathData(**data)
+    assert "values" in str(exc_info.value)
+
+
+# Test Paths
+def test_paths_valid():
+    """Test Paths with valid balance and return data."""
+    data = {
+        "balances": [{"id": 1, "values": {"nominal": [1.0], "real": [1.1]}}],
+        "returns": [{"id": 2, "values": {"nominal": [0.5], "real": [0.6]}}],
+    }
+    paths = Paths(**data)
+    assert len(paths.balances) == 1
+    assert paths.balances[0].id == 1
+    assert len(paths.returns) == 1
+    assert paths.returns[0].id == 2
+
+
+def test_paths_empty_lists():
+    """Test Paths with empty balances and returns lists."""
+    data = {"balances": [], "returns": []}
+    paths = Paths(**data)
+    assert paths.balances == []
+    assert paths.returns == []
+
+
+def test_paths_invalid_balances():
+    """Test Paths with invalid balances type."""
+    data = {
+        "balances": "not_a_list",  # Should be a list of PathData
+        "returns": [{"id": 2, "values": {"nominal": [0.5], "real": [0.6]}}],
+    }
+    with pytest.raises(ValidationError) as exc_info:
+        Paths(**data)
+    assert "balances" in str(exc_info.value)
+
+
+# Test PercentilePath
+def test_percentile_path_valid():
+    """Test PercentilePath with valid percentile and values."""
+    data = {"percentile": 50, "values": {"nominal": [100.0], "real": [105.0]}}
+    pp = PercentilePath(**data)
+    assert pp.percentile == 50
+    assert pp.values.nominal == [100.0]
+
+
+def test_percentile_path_invalid_percentile():
+    """Test PercentilePath with invalid percentile type."""
+    data = {
+        "percentile": "not_an_int",  # Should be an int
+        "values": {"nominal": [100.0], "real": [105.0]},
+    }
+    with pytest.raises(ValidationError) as exc_info:
+        PercentilePath(**data)
+    assert "percentile" in str(exc_info.value)
+
+
+# Test MetricData
+def test_metric_data_valid():
+    """Test MetricData with valid percentile, value, and path id."""
+    data = {
+        "percentile": 75,
+        "value": {"nominal": 200.0, "real": 210.0},
+        "examplePathId": 3,  # camelCase due to CamelModel
+    }
+    md = MetricData(**data)
+    assert md.percentile == 75
+    assert md.value.nominal == 200.0
+    assert md.example_path_id == 3
+
+
+def test_metric_data_invalid_value():
+    """Test MetricData with invalid value type."""
+    data = {
+        "percentile": 75,
+        "value": {"nominal": "bad", "real": 210.0},
+        "examplePathId": 3,
+    }
+    with pytest.raises(ValidationError) as exc_info:
+        MetricData(**data)
+    assert "value" in str(exc_info.value)
+
+
+# Test Parameters
+def test_parameters_valid():
+    """Test Parameters with valid step and path counts."""
+    data = {"numSteps": 100, "numPaths": 50}  # camelCase due to CamelModel
+    params = Parameters(**data)
+    assert params.num_steps == 100
+    assert params.num_paths == 50
+
+
+def test_parameters_negative_values():
+    """Test Parameters with negative num_steps (no validation yet)."""
+    data = {"numSteps": -1, "numPaths": 50}
+    params = Parameters(**data)
+    assert params.num_steps == -1  # Passes unless constrained
+
+
+# Test Metrics
+def test_metrics_valid():
+    """Test Metrics with valid percentile balances and end balance."""
+    data = {
+        "percentileBalances": [
+            {"percentile": 50, "values": {"nominal": [1.0], "real": [1.1]}}
+        ],
+        "endBalance": [
+            {
+                "percentile": 90,
+                "value": {"nominal": 10.0, "real": 11.0},
+                "examplePathId": 1,
+            }
+        ],
+        "meanReturn": [],
+        "volatility": [],
+        "maxDrawdown": [],
+        "contributions": [],
+        "withdrawals": [],
+    }
+    metrics = Metrics(**data)
+    assert len(metrics.percentile_balances) == 1
+    assert metrics.percentile_balances[0].percentile == 50
+    assert len(metrics.end_balance) == 1
+    assert metrics.end_balance[0].percentile == 90
+
+
+# Test Data (Top-Level)
+def test_data_valid():
+    """Test Data with valid parameters, paths, and metrics."""
+    data = {
+        "parameters": {"numSteps": 10, "numPaths": 5},
+        "paths": {
+            "balances": [{"id": 1, "values": {"nominal": [1.0], "real": [1.1]}}],
+            "returns": [],
+        },
+        "metrics": {
+            "percentileBalances": [
+                {"percentile": 50, "values": {"nominal": [2.0], "real": [2.2]}}
+            ],
+            "endBalance": [],
+            "meanReturn": [],
+            "volatility": [],
+            "maxDrawdown": [],
+            "contributions": [],
+            "withdrawals": [],
+        },
+    }
+    full_data = Data(**data)
+    assert full_data.parameters.num_steps == 10
+    assert len(full_data.paths.balances) == 1
+    assert full_data.metrics.percentile_balances[0].percentile == 50
+
+
+def test_data_missing_field():
+    """Test Data with missing metrics field."""
+    data = {
+        "parameters": {"numSteps": 10, "numPaths": 5},
+        "paths": {"balances": [], "returns": []},
+    }
+    with pytest.raises(ValidationError) as exc_info:
+        Data(**data)
+    assert "metrics" in str(exc_info.value)
+
+
+# Test Serialization
+def test_data_serialization():
+    """Test Data serialization to dictionary."""
+    data_instance = Data(
+        parameters=Parameters(num_steps=10, num_paths=5),
+        paths=Paths(
+            balances=[PathData(id=1, values=ValueArray(nominal=[1.0], real=[1.1]))],
+            returns=[],
+        ),
+        metrics=Metrics(
+            percentile_balances=[
+                PercentilePath(
+                    percentile=50, values=ValueArray(nominal=[2.0], real=[2.2])
+                )
+            ],
+            end_balance=[],
+            mean_return=[],
+            volatility=[],
+            max_drawdown=[],
+            contributions=[],
+            withdrawals=[],
+        ),
+    )
+    json_data = data_instance.model_dump(by_alias=True)  # Use aliases for camelCase
+    assert json_data["parameters"]["numSteps"] == 10
+    assert json_data["paths"]["balances"][0]["id"] == 1
+    assert json_data["metrics"]["percentileBalances"][0]["percentile"] == 50


### PR DESCRIPTION
This pull request introduces output schemas to the FastAPI application to standardize response data structures, improve type safety, and enable camelCase JSON output consistent with front-end expectations.